### PR TITLE
모임 게시글 목록: API요청, 무한로딩구현, 헤더 UI수정

### DIFF
--- a/src/api/ReadMeetListRequest.ts
+++ b/src/api/ReadMeetListRequest.ts
@@ -1,3 +1,4 @@
+// ReadMeetListRequest.ts
 import apiClient from './apiClient';
 import Cookies from 'js-cookie';
 
@@ -9,6 +10,16 @@ export interface Meeting {
   eupMyeonDong: string | null;
   gatheringDateTime: string;
   views: number;
+  // 이번에 추가된 필드들
+  latitude: number;
+  longitude: number;
+  author: {
+    token: string;
+    nickname: string;
+    profileImage: string;
+    univName: string;
+  };
+  thumbnail: string | null;
 }
 
 export const ReadMeetListRequest = {

--- a/src/components/Meet/MeetHeader.tsx
+++ b/src/components/Meet/MeetHeader.tsx
@@ -19,70 +19,74 @@ const MeetHeader: React.FC<MeetHeaderProps> = ({ sortBy, setSortBy }) => {
  const [showSortOptions, setShowSortOptions] = useState(false);
 
  return (
-   <>
-     <header className="flex justify-between items-center p-4">
-       <div className="flex-1"></div>
-       <h1 className="text-xl font-semibold flex-1 text-center">모임 찾기</h1>
-       <div className="flex space-x-4 flex-1 justify-end">
-         <FiSearch className="text-2xl" />
-         <FiBell className="text-2xl" />
-       </div>
-     </header>
+  <>
+    <header className="flex justify-between items-center p-4">
+      <div className="flex-1"></div>
+      <h1 className="text-xl font-semibold flex-1 text-center">모임 찾기</h1>
+      <div className="flex space-x-4 flex-1 justify-end">
+        <FiSearch className="text-2xl" />
+        <FiBell className="text-2xl" />
+      </div>
+    </header>
 
-     <div className="flex flex-wrap gap-4 px-4 py-2 text-sm text-gray-600 border-b relative">
-       <button
-         className="flex items-center border border-gray-300 rounded-full px-3 py-1"
-         onClick={() => setShowSortOptions(!showSortOptions)}
-       >
-         {sortByText[sortBy]} ▼
-       </button>
+    {/* 전체 컨테이너 */}
+    <div className="flex flex-wrap items-center gap-4 px-4 py-2 text-sm text-gray-600 border-b relative">
+      {/* 정렬 버튼 */}
+      <button
+        className="w-28 flex items-center justify-between border  border-gray-300 rounded-full px-3 py-1"
+        onClick={() => setShowSortOptions(!showSortOptions)}
+      >
+        <span>{sortByText[sortBy]}</span>
+        <span>▼</span>
+      </button>
 
-       <button className="border border-gray-300 rounded-full px-3 py-1">
-         모집 완료 글 보기
-       </button>
+      {/* 고정 위치의 버튼들 */}
+      <button className="border border-gray-300 rounded-full px-3 py-1">
+        모집 완료 글 보기
+      </button>
 
-       <button
-         className="border border-gray-300 rounded-full px-3 py-1 flex items-center"
-         onClick={() => navigate('/Map')}
-       >
-         <IoMap className="w-4 h-4 mr-1" />
-         지도 뷰
-       </button>
+      <button
+        className="border border-gray-300 rounded-full px-3 py-1 flex items-center"
+        onClick={() => navigate('/Map')}
+      >
+        <IoMap className="w-4 h-4 mr-1" />
+        지도 뷰
+      </button>
 
-       {showSortOptions && (
-         <div className="absolute top-full left-4 mt-1 bg-white border border-gray-300 rounded-md shadow-lg z-10">
-           <button
-             className="block w-full text-left px-4 py-2 hover:bg-gray-100"
-             onClick={() => {
-               setSortBy('DISTANCE');
-               setShowSortOptions(false);
-             }}
-           >
-             가까운거리순
-           </button>
-           <button
-             className="block w-full text-left px-4 py-2 hover:bg-gray-100"
-             onClick={() => {
-               setSortBy('LATEST');
-               setShowSortOptions(false);
-             }}
-           >
-             최신순
-           </button>
-           <button
-             className="block w-full text-left px-4 py-2 hover:bg-gray-100"
-             onClick={() => {
-               setSortBy('GATHERING_DATE');
-               setShowSortOptions(false);
-             }}
-           >
-             모임순
-           </button>
-         </div>
-       )}
-     </div>
-   </>
- );
+      {/* 드롭다운 메뉴 */}
+      {showSortOptions && (
+        <div className="absolute top-full left-4 mt-1 bg-white border border-gray-300 rounded-md shadow-lg z-10 w-28">
+          <button
+            className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+            onClick={() => {
+              setSortBy('DISTANCE');
+              setShowSortOptions(false);
+            }}
+          >
+            가까운거리순
+          </button>
+          <button
+            className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+            onClick={() => {
+              setSortBy('LATEST');
+              setShowSortOptions(false);
+            }}
+          >
+            최신순
+          </button>
+          <button
+            className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+            onClick={() => {
+              setSortBy('GATHERING_DATE');
+              setShowSortOptions(false);
+            }}
+          >
+            모임순
+          </button>
+        </div>
+      )}
+    </div>
+  </>
+);
 };
-
 export default MeetHeader;

--- a/src/pages/Meet.tsx
+++ b/src/pages/Meet.tsx
@@ -1,5 +1,4 @@
-
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import SideBar from '../common/SideBar';
 import MeetHeader from '../components/Meet/MeetHeader';
@@ -12,41 +11,137 @@ import { Meeting } from '../api/ReadMeetListRequest';
 const Meet: React.FC = () => {
   const [sortBy, setSortBy] = useState<'LATEST' | 'DISTANCE' | 'GATHERING_DATE'>('DISTANCE');
   const [meetings, setMeetings] = useState<Meeting[]>([]);
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(true); // 더 불러올 데이터가 있는지 확인
+  const [isLoading, setIsLoading] = useState(false);
+  const observer = useRef<IntersectionObserver>();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const fetchMeetings = async () => {
-      try {
-        if (sortBy === 'DISTANCE') {
-          // 위치 권한 요청 및 에러 처리 추가
-          navigator.geolocation.getCurrentPosition(
-            async (position) => {
-              console.log('현재 위치:', position.coords.latitude, position.coords.longitude);
-              const response = await ReadMeetListRequest.getMeetList(
-                sortBy,
-                position.coords.latitude,
-                position.coords.longitude,
-              );
-              setMeetings(response.data.content);
-            },
-            async (error) => {     
-              console.error('위치 정보를 가져올 수 없습니다:', error);
-              // 위치 정보를 가져올 수 없을 때 기본 위치 사용
-              const response = await ReadMeetListRequest.getMeetList(sortBy);
-              setMeetings(response.data.content);
-            }
-          );
-        } else {
-          const response = await ReadMeetListRequest.getMeetList(sortBy);
-          setMeetings(response.data.content);
-        }
-      } catch (error) {
-        console.error('모임 목록 조회 실패:', error);
+  // 마지막 요소를 관찰하는 콜백 함수
+  const lastMeetingRef = useCallback((node: HTMLDivElement) => {
+    if (isLoading) return;
+    if (observer.current) observer.current.disconnect();
+    
+    observer.current = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting && hasMore) {
+        setPage(prevPage => prevPage + 1);
       }
-    };
+    });
+
+    if (node) observer.current.observe(node);
+  }, [isLoading, hasMore]);
+
+
+
+
+
+//   모임 목록을 불러오는 함수
+//   pageNum - 현재 페이지 번호 (0부터 시작)
+   
+//   1. sortBy 값에 따라 다른 방식으로 데이터를 불러옴
+//   - 'DISTANCE': 현재 위치 기반으로 가까운 순서
+//   - 'LATEST' 또는 'GATHERING_DATE': 기본 위치값 사용
+   
+//   2. 페이지네이션 처리
+//   - pageNum이 0일 때: 새로운 데이터로 교체
+//   - pageNum이 0보다 클 때: 기존 데이터에 새 데이터 추가
   
-    fetchMeetings();
-  }, [sortBy]);
+//   3. 무한 스크롤을 위한 추가 데이터 존재 여부 확인
+//   - response.data.last가 true면 더 이상 데이터가 없음
+ 
+
+const fetchMeetings = useCallback(async (pageNum: number) => {
+  try {
+    setIsLoading(true); // 로딩 상태 시작
+    
+    if (sortBy === 'DISTANCE') {
+      // 위치 기반 정렬일 때는 현재 위치 정보를 가져옴
+      navigator.geolocation.getCurrentPosition(
+        async (position) => {
+          console.log('현재 위치:', position.coords.latitude, position.coords.longitude);
+          // 현재 위치 기반으로 API 호출
+          const response = await ReadMeetListRequest.getMeetList(
+            sortBy,
+            position.coords.latitude,
+            position.coords.longitude,
+            pageNum,
+            10  // 한 페이지당 10개의 데이터
+          );
+          
+          const newData = response.data.content;
+          if (pageNum === 0) {
+            setMeetings(newData); // 첫 페이지면 데이터 교체
+          } else {
+            setMeetings(prev => [...prev, ...newData]); // 이후 페이지는 데이터 추가
+          }
+          
+          // 마지막 페이지 여부 설정
+          setHasMore(!response.data.last);
+        },
+        async (error) => {
+          // 위치 정보를 가져오는데 실패했을 때의 처리
+          console.error('위치 정보를 가져올 수 없습니다:', error);
+          // 기본 위치값으로 API 호출
+          const response = await ReadMeetListRequest.getMeetList(
+            sortBy, 
+            undefined, 
+            undefined, 
+            pageNum, 
+            10
+          );
+          
+          const newData = response.data.content;
+          if (pageNum === 0) {
+            setMeetings(newData);
+          } else {
+            setMeetings(prev => [...prev, ...newData]);
+          }
+          setHasMore(!response.data.last);
+        }
+      );
+    } else {
+      // LATEST 또는 GATHERING_DATE 정렬일 때
+      const response = await ReadMeetListRequest.getMeetList(
+        sortBy, 
+        undefined, 
+        undefined, 
+        pageNum, 
+        10
+      );
+      
+      const newData = response.data.content;
+      if (pageNum === 0) {
+        setMeetings(newData);
+      } else {
+        setMeetings(prev => [...prev, ...newData]);
+      }
+      setHasMore(!response.data.last);
+    }
+  } catch (error) {
+    console.error('모임 목록 조회 실패:', error);
+  } finally {
+    setIsLoading(false); // 로딩 상태 종료
+  }
+}, [sortBy]);  // sortBy가 변경될 때마다 함수 재생성
+
+
+
+
+
+
+  // sortBy가 변경될 때 데이터 초기화 후 다시 불러오기
+  useEffect(() => {
+    setPage(0);
+    setMeetings([]);
+    fetchMeetings(0);
+  }, [sortBy, fetchMeetings]);
+
+  // page가 변경될 때 추가 데이터 불러오기
+  useEffect(() => {
+    if (page > 0) {
+      fetchMeetings(page);
+    }
+  }, [page, fetchMeetings]);
 
   const handleMeetingClick = (id: number) => {
     navigate(`/meet/${id}`);
@@ -57,11 +152,15 @@ const Meet: React.FC = () => {
       <MeetHeader sortBy={sortBy} setSortBy={setSortBy} />
 
       <main className="flex-1 overflow-y-auto relative flex flex-col px-[23px]">
-        {meetings.map(meeting => (
-          <div key={meeting.id} className="border-b py-4 cursor-pointer" onClick={() => handleMeetingClick(meeting.id)}>
+        {meetings.map((meeting, index) => (
+          <div 
+            ref={index === meetings.length - 1 ? lastMeetingRef : null}
+            key={meeting.id} 
+            className="border-b py-4 cursor-pointer" 
+            onClick={() => handleMeetingClick(meeting.id)}
+          >
             <div className="flex justify-between items-start">
               <div>
-                {/* 작성자 정보 표시 추가 */}
                 <div className="text-xs text-gray-500 mb-1">
                   {meeting.author.nickname} · {meeting.author.univName}
                 </div>
@@ -77,7 +176,6 @@ const Meet: React.FC = () => {
                   </div>
                 </div>
               </div>
-              {/* 썸네일 이미지 처리 추가 */}
               <div className="w-16 h-16 rounded-md overflow-hidden">
                 {meeting.thumbnail ? (
                   <img 
@@ -92,6 +190,11 @@ const Meet: React.FC = () => {
             </div>
           </div>
         ))}
+        {isLoading && (
+          <div className="text-center py-4">
+            Loading...
+          </div>
+        )}
       </main>
 
       <div className="right-8 bottom-24 absolute">

--- a/src/pages/Meet.tsx
+++ b/src/pages/Meet.tsx
@@ -1,3 +1,4 @@
+
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import SideBar from '../common/SideBar';
@@ -17,14 +18,24 @@ const Meet: React.FC = () => {
     const fetchMeetings = async () => {
       try {
         if (sortBy === 'DISTANCE') {
-          navigator.geolocation.getCurrentPosition(async position => {
-            const response = await ReadMeetListRequest.getMeetList(
-              sortBy,
-              position.coords.latitude,
-              position.coords.longitude,
-            );
-            setMeetings(response.data.content);
-          });
+          // 위치 권한 요청 및 에러 처리 추가
+          navigator.geolocation.getCurrentPosition(
+            async (position) => {
+              console.log('현재 위치:', position.coords.latitude, position.coords.longitude);
+              const response = await ReadMeetListRequest.getMeetList(
+                sortBy,
+                position.coords.latitude,
+                position.coords.longitude,
+              );
+              setMeetings(response.data.content);
+            },
+            async (error) => {     
+              console.error('위치 정보를 가져올 수 없습니다:', error);
+              // 위치 정보를 가져올 수 없을 때 기본 위치 사용
+              const response = await ReadMeetListRequest.getMeetList(sortBy);
+              setMeetings(response.data.content);
+            }
+          );
         } else {
           const response = await ReadMeetListRequest.getMeetList(sortBy);
           setMeetings(response.data.content);
@@ -33,7 +44,7 @@ const Meet: React.FC = () => {
         console.error('모임 목록 조회 실패:', error);
       }
     };
-
+  
     fetchMeetings();
   }, [sortBy]);
 
@@ -50,6 +61,10 @@ const Meet: React.FC = () => {
           <div key={meeting.id} className="border-b py-4 cursor-pointer" onClick={() => handleMeetingClick(meeting.id)}>
             <div className="flex justify-between items-start">
               <div>
+                {/* 작성자 정보 표시 추가 */}
+                <div className="text-xs text-gray-500 mb-1">
+                  {meeting.author.nickname} · {meeting.author.univName}
+                </div>
                 <div className="text-xs text-gray-500">{meeting.eupMyeonDong || '위치 미정'}</div>
                 <h2 className="font-bold text-lg">{meeting.title}</h2>
                 <div className="text-sm text-gray-600">{new Date(meeting.gatheringDateTime).toLocaleString()}</div>
@@ -62,8 +77,17 @@ const Meet: React.FC = () => {
                   </div>
                 </div>
               </div>
+              {/* 썸네일 이미지 처리 추가 */}
               <div className="w-16 h-16 rounded-md overflow-hidden">
-                <img alt={meeting.title} className="w-full h-full object-cover" />
+                {meeting.thumbnail ? (
+                  <img 
+                    src={meeting.thumbnail} 
+                    alt={meeting.title} 
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full bg-gray-200" />
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
#1 chore: API명세서 변경에 따른 코드 수정


#2 feat: 모임게시글 목록에 무한로딩 구현


#3 fix: 모임 목록 헤더의 버튼들 위치 고정

아래의 사진과 같이 드롭다운 메뉴의 선택에따라 다른 버튼들의 위치들이 밀려서 오른쪽으로 이동하는 문제를 해결
![image](https://github.com/user-attachments/assets/0ed611ad-b999-47e9-b3d3-24b962396438)
![image](https://github.com/user-attachments/assets/2db9c978-4343-4bed-8ed4-c077081d3cbb)
